### PR TITLE
Clarified ambiguous example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ to fetch the user, the access token, or other things:
 // get the user directly
 $user = $client->fetchUser();
 
-// get the access token and then user
+// OR: get the access token and then user
 $accessToken = $client->getAccessToken();
 $user = $client->fetchUserFromToken($accessToken);
 


### PR DESCRIPTION
In the readme there is this example:

```
// get the user directly
$user = $client->fetchUser();

// get the access token and then user
$accessToken = $client->getAccessToken();
$user = $client->fetchUserFromToken($accessToken);
```
What's not quite obvious to the untrained eye in my opinion is that you cannot execute the example code exactly like this, because `$client->fetchUser()` "burns" the authorization code so you cannot use it again in `$client->getAccessToken()`. The OAuth2 server will report an error "code is invalid or expired".
A simple "OR" in the comment should make it more clear that both ways of acquiring the user data are mutually exclusive in the example and not to be executed one after the other.

```
// get the user directly
$user = $client->fetchUser();

// OR: get the access token and then user
$accessToken = $client->getAccessToken();
$user = $client->fetchUserFromToken($accessToken);
```